### PR TITLE
Added the possibility to add custom css to the payment page

### DIFF
--- a/src/Resources/PaymentTypes/Paypage.php
+++ b/src/Resources/PaymentTypes/Paypage.php
@@ -99,6 +99,9 @@ class Paypage extends BasePaymentType
     /** @var bool $card3ds */
     protected $card3ds;
 
+    /** @var array $css */
+    protected $css = [];
+
     /**
      * Paypage constructor.
      *
@@ -533,6 +536,26 @@ class Paypage extends BasePaymentType
     public function setCard3ds($card3ds): Paypage
     {
         $this->card3ds = $card3ds;
+        return $this;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getCss(): ?array
+    {
+        return $this->css;
+    }
+
+    /**
+     * @param array $styles
+     * @return Paypage
+     */
+    public function setCss($styles): Paypage
+    {
+        foreach ($styles as $element => $css) {
+            $this->css[$element] = $css;
+        }
         return $this;
     }
 

--- a/test/integration/PaymentTypes/PaypageTest.php
+++ b/test/integration/PaymentTypes/PaypageTest.php
@@ -72,7 +72,13 @@ class PaypageTest extends BaseIntegrationTest
             ->setContactUrl('https://www.heidelpay.com/en/about-us/about-heidelpay/')
             ->setInvoiceId($invoiceId)
             ->setCard3ds(true)
-            ->setEffectiveInterestRate(4.99);
+            ->setEffectiveInterestRate(4.99)
+            ->setCss([
+                'shopDescription' => 'color: purple',
+                'header' => 'background-color: red',
+                'helpUrl' => 'color: blue',
+                'contactUrl' => 'color: green',
+            ]);
         $this->assertEmpty($paypage->getId());
         $paypage = $this->heidelpay->initPayPageCharge($paypage, $customer, $basket);
         $this->assertNotEmpty($paypage->getId());
@@ -121,7 +127,13 @@ class PaypageTest extends BaseIntegrationTest
             ->setContactUrl('https://www.heidelpay.com/en/about-us/about-heidelpay/')
             ->setInvoiceId($invoiceId)
             ->setCard3ds(true)
-            ->setEffectiveInterestRate(4.99);
+            ->setEffectiveInterestRate(4.99)
+            ->setCss([
+                'shopDescription' => 'color: purple',
+                'header' => 'background-color: red',
+                'helpUrl' => 'color: blue',
+                'contactUrl' => 'color: green',
+            ]);
         $paypage->addExcludeType(Card::getResourceName());
         $this->assertEmpty($paypage->getId());
         $paypage = $this->heidelpay->initPayPageAuthorize($paypage, $customer, $basket);


### PR DESCRIPTION
There was not possibility to add the css as described here:
https://docs.heidelpay.com/docs/hosted-payment-page#2-passing-css-key-to-the-request-body